### PR TITLE
Added base implementation for integration of multiplatform_settings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidx-test-junit = "1.2.1"
 compose-plugin = "1.6.11"
 junit = "4.13.2"
 kotlin = "2.0.20"
+multiplatformSettings = "1.2.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -28,6 +29,7 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -56,7 +56,7 @@ kotlin {
         }
         commonMain.dependencies {
 
-
+            implementation(libs.multiplatform.settings)
 
 
 

--- a/shared/src/androidMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/Settings.android.kt
+++ b/shared/src/androidMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/Settings.android.kt
@@ -1,0 +1,23 @@
+package co.daresay.kmmtemplate.data.storage.preferencies
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.SharedPreferencesSettings
+
+actual fun createSettings(): Settings {
+    val delegate: SharedPreferences = SharedPreferencesProvider.sharedPreferences ?: throw IllegalStateException("SharedPreferences not initialized")
+    return SharedPreferencesSettings(delegate)
+}
+
+//TODO replace this implementation after setup DI framework for providing dependencies
+object SharedPreferencesProvider {
+    var sharedPreferences: SharedPreferences? = null
+
+    fun getInstance(context: Context): SharedPreferences {
+        if (sharedPreferences == null) {
+            sharedPreferences = context.getSharedPreferences(LOCAL_SETTINGS_NAME, Context.MODE_PRIVATE)
+        }
+        return sharedPreferences!!
+    }
+}

--- a/shared/src/commonMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/LocalPreferencesImpl.kt
+++ b/shared/src/commonMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/LocalPreferencesImpl.kt
@@ -1,0 +1,13 @@
+package co.daresay.kmmtemplate.data.storage.preferencies
+
+import com.russhwolf.settings.Settings
+
+class LocalPreferencesImpl(private val settings: Settings) : LocalPreferences {
+    override fun getString(key: String, defaultValue: String): String {
+        return settings.getString(key, defaultValue)
+    }
+
+    override fun setString(key: String, value: String) {
+        settings.putString(key, value)
+    }
+}

--- a/shared/src/commonMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/LocalPreferencies.kt
+++ b/shared/src/commonMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/LocalPreferencies.kt
@@ -1,0 +1,10 @@
+package co.daresay.kmmtemplate.data.storage.preferencies
+
+interface LocalPreferences {
+
+    fun getString(key: String, defaultValue: String): String
+
+    fun setString(key: String, value: String)
+
+    // TODO place other methode if need to store different type of data
+}

--- a/shared/src/commonMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/Settings.kt
+++ b/shared/src/commonMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/Settings.kt
@@ -1,0 +1,7 @@
+package co.daresay.kmmtemplate.data.storage.preferencies
+
+import com.russhwolf.settings.Settings
+
+const val LOCAL_SETTINGS_NAME = "Settings"
+
+expect fun createSettings(): Settings

--- a/shared/src/iosMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/Settings.ios.kt
+++ b/shared/src/iosMain/kotlin/co/daresay/kmmtemplate/data/storage/preferencies/Settings.ios.kt
@@ -1,0 +1,10 @@
+package co.daresay.kmmtemplate.data.storage.preferencies
+
+import com.russhwolf.settings.NSUserDefaultsSettings
+import com.russhwolf.settings.Settings
+import platform.Foundation.NSUserDefaults
+
+actual fun createSettings(): Settings {
+    val delegate: NSUserDefaults = NSUserDefaults.standardUserDefaults()
+    return NSUserDefaultsSettings(delegate)
+}


### PR DESCRIPTION
This is a basic configuration of [mutliplatform_settings](https://github.com/russhwolf/multiplatform-settings#platform-constructors) for storing local stings, which works like Android's SharedPreferences.