### PR TITLE
Added dependencies for voyager screen model implementation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidx-test-junit = "1.2.1"
 compose-plugin = "1.6.11"
 junit = "4.13.2"
 kotlin = "2.0.20"
+voyagerScreenmodel = "1.1.0-beta02"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -28,6 +29,8 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+voyager-koin = { module = "cafe.adriel.voyager:voyager-koin", version.ref = "voyagerScreenmodel" }
+voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyagerScreenmodel" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -55,7 +55,9 @@ kotlin {
 
         }
         commonMain.dependencies {
-
+            implementation(libs.voyager.screenmodel)
+            //remove this dependencies if koin doesn't use as DI
+            implementation(libs.voyager.koin)
 
 
 


### PR DESCRIPTION
Same as with voyager navigation. I can't see how it possible use on iOS side, only in case when we use shared viewModel for iOS. It requires more deeply investigation.